### PR TITLE
Use sc16 over-the-wire (otw) format for transmit and receive examples

### DIFF
--- a/uhd/CHANGELOG.md
+++ b/uhd/CHANGELOG.md
@@ -16,6 +16,7 @@
   `set_rx_gain`
   `set_rx_sample_rate`
   `set_tx_antenna`
+* Use `sc16` over-the-wire format in transmit and receive examples
 
 # 0.1.1 - 2021-03-30
 

--- a/uhd/examples/receive.rs
+++ b/uhd/examples/receive.rs
@@ -1,7 +1,7 @@
 use std::env::set_var;
 
 use anyhow::{Context, Result};
-use num_complex::Complex32;
+use num_complex::Complex;
 use tap::Pipe;
 use uhd::{self, StreamCommand, StreamCommandType, StreamTime, TuneRequest, Usrp};
 
@@ -27,10 +27,10 @@ pub fn main() -> Result<()> {
     usrp.set_rx_frequency(&TuneRequest::with_frequency(2.4e9), CHANNEL)?;
 
     let mut receiver = usrp
-        .get_rx_stream(&uhd::StreamArgs::<Complex32>::new("fc32"))
+        .get_rx_stream(&uhd::StreamArgs::<Complex<i16>>::new("sc16"))
         .unwrap();
 
-    let mut buffer = uhd::alloc_boxed_slice::<Complex32, NUM_SAMPLES>();
+    let mut buffer = uhd::alloc_boxed_slice::<Complex<i16>, NUM_SAMPLES>();
 
     receiver.send_command(&StreamCommand {
         command_type: StreamCommandType::CountAndDone(buffer.len() as u64),

--- a/uhd/examples/transmit.rs
+++ b/uhd/examples/transmit.rs
@@ -2,7 +2,7 @@ use core::f32::consts;
 use std::env::set_var;
 
 use anyhow::{Context, Result};
-use num_complex::Complex32;
+use num_complex::{Complex, Complex32};
 use tap::Pipe;
 use uhd::{self, TuneRequest, Usrp};
 
@@ -34,16 +34,16 @@ pub fn main() -> Result<()> {
 
     // Get TransmitStreamer
     let mut transmitter = usrp
-        .get_tx_stream(&uhd::StreamArgs::<Complex32>::new("fc32"))
+        .get_tx_stream(&uhd::StreamArgs::<Complex<i16>>::new("sc16"))
         .unwrap();
 
     // Generate a sine wave at Fs/4
-    let mut single_chan = uhd::alloc_boxed_slice::<Complex32, NUM_SAMPLES>();
+    let mut single_chan = uhd::alloc_boxed_slice::<Complex<i16>, NUM_SAMPLES>();
     for i in 0..NUM_SAMPLES {
         let t = i as f32 / 4.;
         // z = e^j*2π*theta
         let z = (Complex32::i() * 2. * consts::PI * t).expf(consts::E);
-        single_chan[i] = 0.7 * z;
+        single_chan[i] = Complex::new((8192. * z.re) as i16, (8192. * z.im) as i16);
     }
 
     // Transmit


### PR DESCRIPTION
Use sc16 over-the-wire (otw) format for transmit and receive examples. As discussed in #3. Tested on a USRP B200.

@samcrow As well as this PR, would you consider making a new 0.2.0 release on crates.io that includes the recent changes?