### PR TITLE
Added set clock source

### DIFF
--- a/uhd/examples/receive.rs
+++ b/uhd/examples/receive.rs
@@ -22,6 +22,15 @@ pub fn main() -> Result<()> {
         .pipe(|addr| Usrp::open(&addr))
         .context("Failed to find properly open the USRP")?;
 
+    let _ = usrp.set_clock_source("external", 0);
+    let clock_source = usrp.get_clock_source(0).unwrap();
+    println!("Clock source: {:?}", clock_source);
+    assert_eq!(clock_source, "external");
+    let _ = usrp.set_clock_source("internal", 0);
+    let clock_source = usrp.get_clock_source(0).unwrap();
+    println!("Clock source: {:?}", clock_source);
+    assert_eq!(clock_source, "internal");
+        
     usrp.set_rx_sample_rate(1e6, CHANNEL)?;
     usrp.set_rx_antenna("TX/RX", CHANNEL)?;
     usrp.set_rx_frequency(&TuneRequest::with_frequency(2.4e9), CHANNEL)?;

--- a/uhd/src/usrp.rs
+++ b/uhd/src/usrp.rs
@@ -610,6 +610,12 @@ impl Usrp {
         Ok(time)
     }
 
+    /// Returns the current clock source
+    pub fn set_clock_source(&self, source: &str, mboard: usize) -> Result<(), Error> {
+        let source = CString::new(source)?;
+        check_status(unsafe { uhd_sys::uhd_usrp_set_clock_source(self.0, source.as_ptr(), mboard as _) })
+    }
+    
     /// Enables or disables the receive automatic gain control
     pub fn set_rx_agc_enabled(&mut self, enabled: bool, channel: usize) -> Result<(), Error> {
         check_status(unsafe { uhd_sys::uhd_usrp_set_rx_agc(self.0, enabled, channel as _) })


### PR DESCRIPTION
I added the set_clock_source function. I tested it with a b205mini and UHD 4.6.0.0 on Ubuntu Jammy

```
[INFO] [UHD] linux; GNU C++ version 11.4.0; Boost_107400; UHD_4.6.0.0-0ubuntu1~jammy1
```

The added code in the example is to demonstrate that it works, at least as far as I know.