### PR TITLE
Fix bindgen builds on Apple Silicon macOS

### DIFF
--- a/uhd-sys/CHANGELOG.md
+++ b/uhd-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 - 2024-08-13
+
+* Updated build script to make uhd-sys compile on Apple Silicon macOS devices
+
 # 0.1.2 - 2021-03-30
 
 * Updated build script to make uhd-sys compile on Raspberry Pi devices

--- a/uhd-sys/Cargo.toml
+++ b/uhd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhd-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Sam Crow <scrow@eng.ucsd.edu>"]
 repository = "https://github.com/samcrow/uhd-rust"
 edition = "2018"

--- a/uhd-sys/Cargo.toml
+++ b/uhd-sys/Cargo.toml
@@ -11,6 +11,11 @@ categories = ["external-ffi-bindings", "hardware-support"]
 links = "uhd"
 build = "build.rs"
 
+[lib]
+# output of UHD C++ documentation from bindgen sometimes has 4 spaces, which rustdoc 
+# interprets as markdown-style code, which then triggers failures during doctest
+doctest = false
+
 [dependencies]
 
 [build-dependencies]

--- a/uhd/Cargo.toml
+++ b/uhd/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0.24"
 anyhow = "1.0.39"
 
 [dependencies.uhd-sys]
-version = "0.1.2"
+version = "0.1.3"
 path = "../uhd-sys"
 
 [dev-dependencies]


### PR DESCRIPTION
- Fixes build issues on M-series Macs, where `boost`, and other, libs are provided in `/opt/homebrew/lib`.
  + This is the case when installing UHD driver with `$ brew install uhd`.
- Remove `doctest` failures on bindgen output.
- Some minor `clippy` updates in `build.rs`.