### PR TITLE
Support for timed/bursty TX + Receive error types

### DIFF
--- a/uhd/CHANGELOG.md
+++ b/uhd/CHANGELOG.md
@@ -1,7 +1,12 @@
-# Unreleased
+# [0.4.0](https://github.com/samcrow/uhd-rust/tree/uhd-v0.4.0) - 2026-06-09
+
+## Changed
+
+* Exposed `ReceiveError` to allow receiver logic to handle/match on `ReceiveErrorKind`
 
 ## Added
 
+* Added `TransmitMetadata` builder along with new transmit `send()` method to allow bursty and timed transmissions [#13](https://github.com/samcrow/uhd-rust/issues/13)
 * Time-related methods [#14](https://github.com/samcrow/uhd-rust/pull/14)
 
 # [0.3.0](https://github.com/samcrow/uhd-rust/tree/uhd-v0.3.0) - 2024-05-17

--- a/uhd/src/error.rs
+++ b/uhd/src/error.rs
@@ -112,7 +112,8 @@ pub(crate) fn check_status(status: uhd_sys::uhd_error::Type) -> Result<()> {
         uhd_error::UHD_ERROR_EXCEPT => Some(Except),
         uhd_error::UHD_ERROR_BOOSTEXCEPT => Some(BoostExcept),
         uhd_error::UHD_ERROR_STDEXCEPT => Some(StdExcept),
-        uhd_error::UHD_ERROR_UNKNOWN | _ => Some(Unknown),
+        uhd_error::UHD_ERROR_UNKNOWN => Some(Unknown),
+        _ => Some(Unknown),
     };
     match iserr {
         std::option::Option::Some(e) => Err(e),

--- a/uhd/src/lib.rs
+++ b/uhd/src/lib.rs
@@ -33,7 +33,7 @@ mod utils;
 pub use daughter_board_eeprom::DaughterBoardEeprom;
 pub use error::*;
 pub use motherboard_eeprom::MotherboardEeprom;
-pub use receiver::{info::ReceiveInfo, metadata::*, streamer::ReceiveStreamer};
+pub use receiver::{error::*, info::ReceiveInfo, metadata::*, streamer::ReceiveStreamer};
 pub use stream::*;
 pub use transmitter::{info::TransmitInfo, metadata::*, streamer::TransmitStreamer};
 pub use tune_request::*;

--- a/uhd/src/range.rs
+++ b/uhd/src/range.rs
@@ -61,6 +61,11 @@ impl MetaRange {
         length
     }
 
+    /// Checks if meta-range is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the range at the provided index, if one exists
     pub fn get(&self, index: usize) -> Option<Range> {
         let mut range = Range::default();

--- a/uhd/src/receiver/metadata.rs
+++ b/uhd/src/receiver/metadata.rs
@@ -33,8 +33,8 @@ impl ReceiveMetadata {
                 )
             })
             .unwrap();
-            // Convert seconds from time_t to i64
-            time.seconds = seconds_time_t.into();
+
+            time.seconds = seconds_time_t;
             Some(time)
         } else {
             None
@@ -219,10 +219,10 @@ mod test {
     fn default_rx_metadata() {
         let metadata = ReceiveMetadata::default();
         assert_eq!(None, metadata.time_spec());
-        assert_eq!(false, metadata.start_of_burst());
-        assert_eq!(false, metadata.end_of_burst());
-        assert_eq!(false, metadata.out_of_sequence());
-        assert_eq!(false, metadata.more_fragments());
+        assert!(!metadata.start_of_burst());
+        assert!(!metadata.end_of_burst());
+        assert!(!metadata.out_of_sequence());
+        assert!(!metadata.more_fragments());
         assert_eq!(0, metadata.fragment_offset());
         assert!(metadata.last_error().is_none());
     }

--- a/uhd/src/receiver/metadata.rs
+++ b/uhd/src/receiver/metadata.rs
@@ -20,6 +20,7 @@ impl ReceiveMetadata {
 
     /// Returns the timestamp of (the first?) of the received samples, according to the USRP's
     /// internal clock
+    #[allow(clippy::useless_conversion)]
     pub fn time_spec(&self) -> Option<TimeSpec> {
         if self.has_time_spec() {
             let mut time = TimeSpec::default();
@@ -33,8 +34,9 @@ impl ReceiveMetadata {
                 )
             })
             .unwrap();
-
-            time.seconds = seconds_time_t;
+            // Explicitly convert seconds from time_t to i64 (some platforms `time_t` is smaller
+            // than `i64`)
+            time.seconds = seconds_time_t.into();
             Some(time)
         } else {
             None

--- a/uhd/src/stream/mod.rs
+++ b/uhd/src/stream/mod.rs
@@ -1,5 +1,5 @@
 use num_complex::{Complex, Complex32, Complex64};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::ffi::{CString, NulError};
 use std::marker::PhantomData;
 
@@ -49,7 +49,7 @@ impl<I> Default for StreamArgs<I> {
     /// and default arguments and channels
     fn default() -> Self {
         StreamArgs {
-            host_format: PhantomData::default(),
+            host_format: PhantomData,
             wire_format: "sc16".to_string(),
             args: "".to_string(),
             // Empty list = just channel 0
@@ -204,15 +204,11 @@ impl StreamCommand {
             }
             StreamCommandType::CountAndDone(samples) => {
                 c_cmd.stream_mode = uhd_sys::uhd_stream_mode_t::UHD_STREAM_MODE_NUM_SAMPS_AND_DONE;
-                c_cmd.num_samps = samples
-                    .try_into()
-                    .expect("Number of samples too large for size_t");
+                c_cmd.num_samps = samples;
             }
             StreamCommandType::CountAndMore(samples) => {
                 c_cmd.stream_mode = uhd_sys::uhd_stream_mode_t::UHD_STREAM_MODE_NUM_SAMPS_AND_MORE;
-                c_cmd.num_samps = samples
-                    .try_into()
-                    .expect("Number of samples too large for size_t");
+                c_cmd.num_samps = samples;
             }
         };
         c_cmd

--- a/uhd/src/stream/mod.rs
+++ b/uhd/src/stream/mod.rs
@@ -1,5 +1,5 @@
 use num_complex::{Complex, Complex32, Complex64};
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::ffi::{CString, NulError};
 use std::marker::PhantomData;
 
@@ -195,6 +195,7 @@ impl StreamCommand {
         // In some versions of UHD, num_samps is a size_t. In other versions, it's a uint64_t.
         // The Rust code always uses u64, and converts here.
 
+        #[allow(clippy::useless_conversion)]
         match self.command_type {
             StreamCommandType::StartContinuous => {
                 c_cmd.stream_mode = uhd_sys::uhd_stream_mode_t::UHD_STREAM_MODE_START_CONTINUOUS;
@@ -204,11 +205,15 @@ impl StreamCommand {
             }
             StreamCommandType::CountAndDone(samples) => {
                 c_cmd.stream_mode = uhd_sys::uhd_stream_mode_t::UHD_STREAM_MODE_NUM_SAMPS_AND_DONE;
-                c_cmd.num_samps = samples;
+                c_cmd.num_samps = samples
+                    .try_into()
+                    .expect("Number of samples too large for size_t");
             }
             StreamCommandType::CountAndMore(samples) => {
                 c_cmd.stream_mode = uhd_sys::uhd_stream_mode_t::UHD_STREAM_MODE_NUM_SAMPS_AND_MORE;
-                c_cmd.num_samps = samples;
+                c_cmd.num_samps = samples
+                    .try_into()
+                    .expect("Number of samples too large for size_t");
             }
         };
         c_cmd

--- a/uhd/src/transmitter/metadata.rs
+++ b/uhd/src/transmitter/metadata.rs
@@ -52,6 +52,7 @@ impl TransmitMetadata {
 
     /// Returns the timestamp of (the first?) of the transmitted samples, according to the USRP's
     /// internal clock
+    #[allow(clippy::useless_conversion)]
     pub fn time_spec(&self) -> Option<TimeSpec> {
         if self.has_time_spec() {
             let mut time = TimeSpec::default();
@@ -66,7 +67,9 @@ impl TransmitMetadata {
             })
             .unwrap();
 
-            time.seconds = seconds_time_t;
+            // Explicitly convert seconds from time_t to i64 (some platforms `time_t` is smaller
+            // than `i64`)
+            time.seconds = seconds_time_t.into();
             Some(time)
         } else {
             None

--- a/uhd/src/transmitter/metadata.rs
+++ b/uhd/src/transmitter/metadata.rs
@@ -17,6 +17,39 @@ impl TransmitMetadata {
         Default::default()
     }
 
+    /// Build a `TransmitMetadata` with explicit burst flags and an optional time spec.
+    ///
+    /// Useful for burst transmissions. Per the Ettus documentation, the first packet of a
+    /// burst should carry `start_of_burst = true` and the last packet should carry
+    /// `end_of_burst = true` so the radio can bracket the burst cleanly (RF enabled
+    /// at SOB, disabled at EOB, fresh re-init on the next SOB).
+    ///
+    /// `Default::default()` constructs metadata with all three fields cleared, which
+    /// is appropriate for continuous-streaming workloads.
+    pub fn with_flags(
+        start_of_burst: bool,
+        end_of_burst: bool,
+        time_spec: Option<TimeSpec>,
+    ) -> Self {
+        let (has_time_spec, full_secs, frac_secs) = match time_spec {
+            Some(t) => (true, t.seconds, t.fraction),
+            None => (false, 0i64, 0.0f64),
+        };
+        let mut handle: uhd_sys::uhd_tx_metadata_handle = ptr::null_mut();
+        check_status(unsafe {
+            uhd_sys::uhd_tx_metadata_make(
+                &mut handle,
+                has_time_spec,
+                full_secs,
+                frac_secs,
+                start_of_burst,
+                end_of_burst,
+            )
+        })
+        .unwrap();
+        TransmitMetadata { handle, samples: 0 }
+    }
+
     /// Returns the timestamp of (the first?) of the transmitted samples, according to the USRP's
     /// internal clock
     pub fn time_spec(&self) -> Option<TimeSpec> {
@@ -32,8 +65,8 @@ impl TransmitMetadata {
                 )
             })
             .unwrap();
-            // Convert seconds from time_t to i64
-            time.seconds = seconds_time_t.into();
+
+            time.seconds = seconds_time_t;
             Some(time)
         } else {
             None
@@ -139,7 +172,33 @@ mod test {
     fn default_tx_metadata() {
         let metadata = TransmitMetadata::default();
         assert_eq!(None, metadata.time_spec());
-        assert_eq!(false, metadata.start_of_burst());
-        assert_eq!(false, metadata.end_of_burst());
+        assert!(!metadata.start_of_burst());
+        assert!(!metadata.end_of_burst());
+    }
+
+    #[test]
+    fn with_flags_sob_eob_round_trip() {
+        let md = TransmitMetadata::with_flags(true, true, None);
+        assert!(md.start_of_burst());
+        assert!(md.end_of_burst());
+        assert_eq!(None, md.time_spec());
+    }
+
+    #[test]
+    fn with_flags_time_spec_round_trip() {
+        use crate::TimeSpec;
+        let md = TransmitMetadata::with_flags(
+            true,
+            false,
+            Some(TimeSpec {
+                seconds: 42,
+                fraction: 0.125,
+            }),
+        );
+        assert!(md.start_of_burst());
+        assert!(!md.end_of_burst());
+        let t = md.time_spec().expect("time_spec should be Some");
+        assert_eq!(42, t.seconds);
+        assert!((t.fraction - 0.125).abs() < 1e-12);
     }
 }

--- a/uhd/src/transmitter/streamer.rs
+++ b/uhd/src/transmitter/streamer.rs
@@ -64,22 +64,27 @@ impl<I> TransmitStreamer<'_, I> {
         num_channels
     }
 
-    /// transmits samples from the USRP
+    /// Transmits samples with caller-provided metadata.
     ///
-    /// buffers: One or more buffers (one per channel) containing sample to transmit. All
-    /// buffers should have the same length. This function will panic if the number of buffers
-    /// is not equal to self.num_channels(), or if not all buffers have the same length.
+    /// Use this when you need to set `start_of_burst`, `end_of_burst`, or a time spec
+    /// on the send (e.x for bursty TX, see [`TransmitMetadata::with_flags`])
     ///
-    /// timeout: The timeout for the transmit operation, in seconds
+    /// `buffers`: one or more sample buffers (one per channel). Panics if the number
+    /// of buffers doesn't match `self.num_channels()` or if buffer lengths differ.
     ///
-    /// On success, this function returns a transmitMetadata object with information about
-    /// the number of samples actually transmitd.
-    pub fn transmit(
+    /// `metadata`: caller-owned. The `samples` field is updated in place with the
+    /// number of samples actually accepted by the streamer.
+    ///
+    /// `timeout`: the timeout for the send operation, in seconds.
+    ///
+    /// Returns the number of samples actually accepted by the streamer (may be less
+    /// than the buffer length on partial sends).
+    pub fn send(
         &mut self,
         buffers: &mut [&[I]],
+        metadata: &mut TransmitMetadata,
         timeout: f64,
-    ) -> Result<TransmitMetadata, Error> {
-        let mut metadata = TransmitMetadata::default();
+    ) -> Result<usize, Error> {
         let mut samples_transmitted = 0usize;
 
         // Initialize buffer_pointers
@@ -113,6 +118,29 @@ impl<I> TransmitStreamer<'_, I> {
         })?;
         metadata.set_samples(samples_transmitted);
 
+        Ok(samples_transmitted)
+    }
+
+    /// Transmits samples from the USRP using default (continuous-stream) metadata —
+    /// `start_of_burst = false`, `end_of_burst = false`, no time spec.
+    ///
+    /// For bursty transmission (discrete packets separated by gaps), use `send` with
+    /// `TransmitMetadata::with_flags` instead.
+    ///
+    /// `buffers`: one or more sample buffers (one per channel). Panics if the number
+    /// of buffers doesn't match `self.num_channels()` or if buffer lengths differ.
+    ///
+    /// `timeout`: the timeout for the transmit operation, in seconds.
+    ///
+    /// On success, returns the freshly-built `TransmitMetadata` with `samples()`
+    /// reflecting the number of samples actually accepted by the streamer.
+    pub fn transmit(
+        &mut self,
+        buffers: &mut [&[I]],
+        timeout: f64,
+    ) -> Result<TransmitMetadata, Error> {
+        let mut metadata = TransmitMetadata::default();
+        self.send(buffers, &mut metadata, timeout)?;
         Ok(metadata)
     }
 

--- a/uhd/src/usrp.rs
+++ b/uhd/src/usrp.rs
@@ -623,7 +623,7 @@ impl Usrp {
                 &mut time.fraction,
             )
         })?;
-        time.seconds = seconds_time_t.into();
+        time.seconds = seconds_time_t;
         Ok(time)
     }
 

--- a/uhd/src/usrp.rs
+++ b/uhd/src/usrp.rs
@@ -611,6 +611,7 @@ impl Usrp {
     }
 
     /// Returns the USRP's current time. Commands can be scheduled relative to this time.
+    #[allow(clippy::useless_conversion)]
     pub fn get_current_time(&self, mboard: usize) -> Result<TimeSpec, Error> {
         let mut time = TimeSpec::default();
         let mut seconds_time_t: libc::time_t = Default::default();
@@ -623,7 +624,7 @@ impl Usrp {
                 &mut time.fraction,
             )
         })?;
-        time.seconds = seconds_time_t;
+        time.seconds = seconds_time_t.into();
         Ok(time)
     }
 


### PR DESCRIPTION
- Allows timed and burst transmit operations via `TransmitMetadata` builder and new `send()` TX method (should fix #13 ). Verified running on my Ettus B205mini on macOS, which also fixed issues I was seeing with packetized transmit modes.
- Exposes `ReceiveErrorKind` types to allow receiver logic to handle/match returned status from receives.
- Minor `clippy` fixes.

I updated the `uhd` changelog with a version bump to `0.4.0` but I can change that to `unreleased` if you'd prefer.