### PR TITLE
Bump uhd version to 0.4.0

### DIFF
--- a/uhd/Cargo.toml
+++ b/uhd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uhd"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sam Crow <scrow@eng.ucsd.edu>"]
 edition = "2018"
 description = "Bindings to the UHD (USRP Hardware Driver) library, which provides support for Ettus Research / National Instruments Universal Software Radio Peripheral devices"


### PR DESCRIPTION
@samcrow apologies, forgot to bump the `Cargo.toml` version to match the Changelog and publish last PR.