### PR TITLE
Bump bindgen dependency

### DIFF
--- a/uhd-sys/CHANGELOG.md
+++ b/uhd-sys/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Updated `bindgen` dependency to pick up security fixes for transitive
+  dependencies.
+
 # 0.1.3 - 2024-08-13
 
 * Updated build script to make uhd-sys compile on Apple Silicon macOS devices

--- a/uhd-sys/Cargo.toml
+++ b/uhd-sys/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [build-dependencies]
 metadeps = "1.1.2"
-bindgen = "0.55.1"
+bindgen = "0.69"
 
 [package.metadata.pkg-config]
 uhd = "*"

--- a/uhd-sys/build.rs
+++ b/uhd-sys/build.rs
@@ -25,7 +25,7 @@ fn generate_bindings(include_path: &Path) {
     let out_path = out_dir.join("bindgen.rs");
 
     let mut builder = bindgen::builder()
-        .whitelist_function("^uhd.+")
+        .allowlist_function("^uhd.+")
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .header(usrp_header.to_string_lossy().clone())
         // Add the include directory to ensure that #includes in the header work correctly


### PR DESCRIPTION
This fixes these issues from transitive dependencies:
* RUSTSEC-2021-0139
* RUSTSEC-2024-0375
* RUSTSEC-2024-0006